### PR TITLE
Prevent 301 redirects for Pinterest link

### DIFF
--- a/src/Channels/Pinterest.php
+++ b/src/Channels/Pinterest.php
@@ -14,6 +14,6 @@ class Pinterest implements Channel
             'description' => $params->get('text'),
         ];
 
-        return 'https://pinterest.com/pin/create/button' . '?' . http_build_query($query);
+        return 'https://www.pinterest.com/pin/create/button/' . '?' . http_build_query($query);
     }
 }


### PR DESCRIPTION
I noticed Pinterest is redirecting all `https://pinterest.com/pin/create/button` links to `https://www.pinterest.com/pin/create/button/` while auditing links on one of my websites. This change just prevents an extra redirect hop.