### PR TITLE
Version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SocialLinks ![Statamic](https://flat.badgen.net/badge/Statamic/3.0+/FF269E)
-This addon provides an easy way to generate social profile and sharing links for channels like Facebook, Twitter and more.
+This addon provides an easy way to create social profile and sharing links for channels like Facebook, Twitter and more.
 
 ## Installation
 Install the addon using Composer.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SocialLinks ![Statamic](https://flat.badgen.net/badge/Statamic/3.0+/FF269E)
-This addon provides an easy way to generate social sharing links for channels like Facebook, Twitter and more.
+This addon provides an easy way to generate social profile and sharing links for channels like Facebook, Twitter and more.
 
 ## Installation
 Install the addon using Composer.
@@ -13,60 +13,52 @@ composer require aerni/social-links
 ## Supported Channels
 
 This addon supports the following social channels:
-`Facebook`, `LinkedIn`, `Mail`, `Pinterest`, `Telegram`, `Twitter`, `WhatsApp`, `Xing`
+`Facebook`, `Instagram`, `LinkedIn`, `Mail`, `Pinterest`, `Telegram`, `Twitter`, `Vimeo`, `WhatsApp`, `Xing`, `YouTube`
 
 ***
 
-## Basic Usage
+## Profile Link
 
-To create a sharing link, you have to call the tag followed by the channel of your choice.
+Create a link to a social profile by providing the social `channel` and `handle` of the profile:
 
-```template
-<!-- Facebook -->
-{{ social_links:facebook }}
-
-<!-- LinkedIn -->
-{{ social_links:linkedin }}
-
-<!-- Mail -->
-{{ social_links:mail }}
-
-<!-- Pinterest -->
-{{ social_links:pinterest }}
-
-<!-- Telegram -->
-{{ social_links:telegram }}
-
-<!-- Twitter -->
-{{ social_links:twitter }}
-
-<!-- WhatsApp -->
-{{ social_links:whatsapp }}
-
-<!-- Xing -->
-{{ social_links:xing }}
+```antlers
+{{ social:profile channel="facebook" handle="michaelaerni" }}
 ```
 
-The tag will use the URL of the current page by default. If you want to share a different URL, you may pass it using the `url` parameter.
+Or using the shorthand:
 
-```template
-{{ social_links:facebook url="https://www.myveryspecialwebsite.com" }}
+```antlers
+{{ social:facebook:profile handle="michaelaerni" }}
 ```
 
 ***
 
-## Parameters
+## Sharing Link
 
-You may pass the following parameters to customize the generated link.
+Create a sharing link by providing the social `channel`:
 
-### Facebook
+```antlers
+{{ social:share channel="facebook" }}
+```
+
+Or using the shorthand:
+
+```antlers
+{{ social:facebook:share }}
+```
+
+### Parameters
+
+There are a number of parameters you may use to customize the sharing links:
+
+#### Facebook
 
 | Name | Description | Usage |
 |------|-------------|-------|
 | `url` | The URL of the page to share | Optional
 | `text` | The text of your post | Optional
 
-### LinkedIn
+#### LinkedIn
 
 | Name | Description | Usage |
 |------|-------------|-------|
@@ -75,7 +67,7 @@ You may pass the following parameters to customize the generated link.
 | `text` | The text of your post | Optional
 | `source` | The source of your post | Optional
 
-### Mail
+#### Mail
 
 | Name | Description | Usage |
 |------|-------------|-------|
@@ -88,25 +80,25 @@ You may pass the following parameters to customize the generated link.
 
 The `url` will be placed in the body of the email by default. You can customize the email body text by using the `body` parameter. Note, that this will override the default body text that includes the `url`. You will have to manually add the `url` in the `body` parameter like so:
 
-```template
-{{ social_links:mail body="I want to share this great site with you: {permalink}" }}
+```antlers
+{{ social:mail:share body="I want to share this great site with you: {permalink}" }}
 ```
 
-### Pinterest
+#### Pinterest
 
 | Name | Description | Usage |
 |------|-------------|-------|
 | `url` | The URL of the page to share | Optional
 | `image` | The image to share | Optional
 
-### Telegram
+#### Telegram
 
 | Name | Description | Usage |
 |------|-------------|-------|
 | `url` | The URL of the page to share | Optional
 | `text` | The description of your shared page | Optional
 
-### Twitter
+#### Twitter
 
 | Name | Description | Usage |
 |------|-------------|-------|
@@ -114,14 +106,54 @@ The `url` will be placed in the body of the email by default. You can customize 
 | `text` | The text of your Tweet | Optional
 | `handle` | The twitter handle you want to add to the Tweet | Optional
 
-### WhatsApp
+#### WhatsApp
 
 | Name | Description | Usage |
 |------|-------------|-------|
 | `url` | The URL of the page to share | Optional
 
-### Xing
+#### Xing
 
 | Name | Description | Usage |
 |------|-------------|-------|
 | `url` | The URL of the page to share | Optional
+
+
+***
+
+## Channel Name
+
+Get the name of a social channel:
+
+```antlers
+{{ social:name channel="facebook" }}
+```
+
+Or using the shorthand:
+
+```antlers
+{{ social:facebook:name }}
+```
+***
+
+## Tag Pair
+
+You may also use a tag pair to get all the data at once:
+
+```antlers
+{{ social channel="facebook" handle="michaelaerni" }}
+  {{ profile }}
+  {{ share }}
+  {{ name }}
+{{ /social }}
+```
+
+Or using the shorthand:
+
+```antlers
+{{ social:facebook handle="michaelaerni" }}
+  {{ profile }}
+  {{ share }}
+  {{ name }}
+{{ /social:facebook }}`
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ composer require aerni/social-links
 ## Supported Channels
 
 This addon supports the following social channels:
-`Facebook`, `Instagram`, `LinkedIn`, `Mail`, `Pinterest`, `Telegram`, `Twitter`, `Vimeo`, `WhatsApp`, `Xing`, `YouTube`
+`Facebook`, `GitHub`, `Instagram`, `LinkedIn`, `Mail`, `Pinterest`, `Telegram`, `Twitter`, `Vimeo`, `WhatsApp`, `Xing`, `YouTube`
 
 ***
 

--- a/src/ChannelManager.php
+++ b/src/ChannelManager.php
@@ -9,6 +9,7 @@ use Aerni\SocialLinks\Channels\Channel;
 use Aerni\SocialLinks\Channels\Twitter;
 use Aerni\SocialLinks\Channels\YouTube;
 use Aerni\SocialLinks\Channels\Facebook;
+use Aerni\SocialLinks\Channels\GitHub;
 use Aerni\SocialLinks\Channels\LinkedIn;
 use Aerni\SocialLinks\Channels\Telegram;
 use Aerni\SocialLinks\Channels\WhatsApp;
@@ -19,6 +20,7 @@ class ChannelManager
 {
     protected array $channels = [
         Facebook::class,
+        GitHub::class,
         Instagram::class,
         LinkedIn::class,
         Mail::class,

--- a/src/ChannelManager.php
+++ b/src/ChannelManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Aerni\SocialLinks;
+
+use Aerni\SocialLinks\Channels\Mail;
+use Aerni\SocialLinks\Channels\Xing;
+use Aerni\SocialLinks\Channels\Vimeo;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Channels\Twitter;
+use Aerni\SocialLinks\Channels\YouTube;
+use Aerni\SocialLinks\Channels\Facebook;
+use Aerni\SocialLinks\Channels\LinkedIn;
+use Aerni\SocialLinks\Channels\Telegram;
+use Aerni\SocialLinks\Channels\WhatsApp;
+use Aerni\SocialLinks\Channels\Instagram;
+use Aerni\SocialLinks\Channels\Pinterest;
+
+class ChannelManager
+{
+    protected array $channels = [
+        Facebook::class,
+        Instagram::class,
+        LinkedIn::class,
+        Mail::class,
+        Pinterest::class,
+        Telegram::class,
+        Twitter::class,
+        Vimeo::class,
+        WhatsApp::class,
+        Xing::class,
+        YouTube::class,
+    ];
+
+    public static function find(string $channel): ?Channel
+    {
+        return collect((new static)->channels)
+            ->map(fn ($class) => app($class))
+            ->first(fn ($class) => $class->handle() === $channel);
+    }
+}

--- a/src/Channels/Channel.php
+++ b/src/Channels/Channel.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Collection;
 
 class Channel
 {
+    protected $decodeShareUrlQuery = false;
+
     protected Collection $params;
 
     public function __construct()

--- a/src/Channels/Channel.php
+++ b/src/Channels/Channel.php
@@ -4,7 +4,38 @@ namespace Aerni\SocialLinks\Channels;
 
 use Illuminate\Support\Collection;
 
-interface Channel
+class Channel
 {
-    public static function create(Collection $params): string;
+    protected Collection $params;
+
+    public function __construct()
+    {
+        $this->params = collect();
+    }
+
+    public function params(Collection $params): self
+    {
+        $this->params = $params;
+
+        return $this;
+    }
+
+    public function all(): array
+    {
+        return array_filter([
+            'profile' => method_exists($this, 'profileUrl') ? $this->profileUrl() : null,
+            'share' => method_exists($this, 'shareUrl') ? $this->shareUrl() : null,
+            'name' => $this->name(),
+        ]);
+    }
+
+    public function name(): string
+    {
+        return class_basename($this);
+    }
+
+    public function handle(): string
+    {
+        return strtolower($this->name());
+    }
 }

--- a/src/Channels/Facebook.php
+++ b/src/Channels/Facebook.php
@@ -2,17 +2,30 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
 
-class Facebook implements Channel
+class Facebook extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'u' => $params->get('url'),
-            'quote' => $params->get('text'),
-        ];
+    use WithProfileUrl;
+    use WithShareUrl;
 
-        return 'https://www.facebook.com/sharer/sharer.php' . '?' . http_build_query($query);
+    protected function profileBaseUrl(): string
+    {
+        return 'https://www.facebook.com/in/';
+    }
+
+    protected function shareBaseUrl(): string
+    {
+        return 'https://www.facebook.com/sharer/sharer.php';
+    }
+
+    protected function shareUrlParams(): array
+    {
+        return [
+            'u' => $this->params->get('url'),
+            'quote' => $this->params->get('text'),
+        ];
     }
 }

--- a/src/Channels/GitHub.php
+++ b/src/Channels/GitHub.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aerni\SocialLinks\Channels;
+
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+
+class GitHub extends Channel
+{
+    use WithProfileUrl;
+
+    public function profileBaseUrl(): string
+    {
+        return 'https://github.com/';
+    }
+}

--- a/src/Channels/Instagram.php
+++ b/src/Channels/Instagram.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aerni\SocialLinks\Channels;
+
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+
+class Instagram extends Channel
+{
+    use WithProfileUrl;
+
+    protected function profileBaseUrl(): string
+    {
+        return 'https://www.instagram.com/';
+    }
+}

--- a/src/Channels/Linkedin.php
+++ b/src/Channels/Linkedin.php
@@ -2,20 +2,36 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
 
-class Linkedin implements Channel
+class LinkedIn extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'mini' => 'true',
-            'url' => $params->get('url'),
-            'title' => $params->get('title'),
-            'summary' => $params->get('text'),
-            'source' => $params->get('source'),
-        ];
+    use WithProfileUrl;
+    use WithShareUrl;
 
-        return 'https://www.linkedin.com/shareArticle' . '?' . http_build_query($query);
+    public function profileBaseUrl(): string
+    {
+        return match (true) {
+            ($this->params->get('type') === 'company') => 'https://www.linkedin.com/company/',
+            default => 'https://www.linkedin.com/in/',
+        };
+    }
+
+    public function shareBaseUrl(): string
+    {
+        return 'https://www.linkedin.com/shareArticle';
+    }
+
+    public function shareUrlParams(): array
+    {
+        return [
+            'mini' => 'true',
+            'url' => $this->params->get('url'),
+            'title' => $this->params->get('title'),
+            'summary' => $this->params->get('text'),
+            'source' => $this->params->get('source'),
+        ];
     }
 }

--- a/src/Channels/Mail.php
+++ b/src/Channels/Mail.php
@@ -9,6 +9,8 @@ class Mail extends Channel
 {
     use WithShareUrl;
 
+    protected $decodeShareUrlQuery = true;
+
     public function shareBaseUrl(): string
     {
         return 'mailto:' . $this->params->get('to');

--- a/src/Channels/Mail.php
+++ b/src/Channels/Mail.php
@@ -2,19 +2,25 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
 
-class Mail implements Channel
+class Mail extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'cc' => $params->get('cc'),
-            'bcc' => $params->get('bcc'),
-            'subject' => $params->get('subject'),
-            'body' => $params->get('body') ?? $params->get('url')
-        ];
+    use WithShareUrl;
 
-        return 'mailto:' . $params->get('to') . '?' . urldecode(http_build_query($query));
+    public function shareBaseUrl(): string
+    {
+        return 'mailto:' . $this->params->get('to');
+    }
+
+    public function shareUrlParams(): array
+    {
+        return [
+            'cc' => $this->params->get('cc'),
+            'bcc' => $this->params->get('bcc'),
+            'subject' => $this->params->get('subject'),
+            'body' => $this->params->get('body') ?? $this->params->get('url'),
+        ];
     }
 }

--- a/src/Channels/Pinterest.php
+++ b/src/Channels/Pinterest.php
@@ -2,18 +2,31 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
 
-class Pinterest implements Channel
+class Pinterest extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'url' => $params->get('url'),
-            'media' => $params->get('image'),
-            'description' => $params->get('text'),
-        ];
+    use WithProfileUrl;
+    use WithShareUrl;
 
-        return 'https://www.pinterest.com/pin/create/button/' . '?' . http_build_query($query);
+    public function profileBaseUrl(): string
+    {
+        return 'https://www.pinterest.com/';
+    }
+
+    public function shareBaseUrl(): string
+    {
+        return 'https://www.pinterest.com/pin/create/button/';
+    }
+
+    public function shareUrlParams(): array
+    {
+        return [
+            'url' => $this->params->get('url'),
+            'media' => $this->params->get('image'),
+            'description' => $this->params->get('text'),
+        ];
     }
 }

--- a/src/Channels/Telegram.php
+++ b/src/Channels/Telegram.php
@@ -2,17 +2,23 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
 
-class Telegram implements Channel
+class Telegram extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'url' => $params->get('url'),
-            'text' => $params->get('text'),
-        ];
+    use WithShareUrl;
 
-        return 'https://t.me/share/url' . '?' . http_build_query($query);
+    public function shareBaseUrl(): string
+    {
+        return 'https://t.me/share/url';
+    }
+
+    public function shareUrlParams(): array
+    {
+        return [
+            'url' => $this->params->get('url'),
+            'text' => $this->params->get('text'),
+        ];
     }
 }

--- a/src/Channels/Twitter.php
+++ b/src/Channels/Twitter.php
@@ -2,18 +2,31 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
 
-class Twitter implements Channel
+class Twitter extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'url' => $params->get('url'),
-            'text' => $params->get('text'),
-            'via' => $params->get('handle'),
-        ];
+    use WithProfileUrl;
+    use WithShareUrl;
 
-        return 'https://twitter.com/intent/tweet' . '?' . http_build_query($query);
+    public function profileBaseUrl(): string
+    {
+        return 'https://www.twitter.com/';
+    }
+
+    public function shareBaseUrl(): string
+    {
+        return 'https://twitter.com/intent/tweet';
+    }
+
+    public function shareUrlParams(): array
+    {
+        return [
+            'url' => $this->params->get('url'),
+            'text' => $this->params->get('text'),
+            'via' => $this->params->get('handle'),
+        ];
     }
 }

--- a/src/Channels/Vimeo.php
+++ b/src/Channels/Vimeo.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aerni\SocialLinks\Channels;
+
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+
+class Vimeo extends Channel
+{
+    use WithProfileUrl;
+
+    public function profileBaseUrl(): string
+    {
+        return 'https://www.vimeo.com/';
+    }
+}

--- a/src/Channels/Whatsapp.php
+++ b/src/Channels/Whatsapp.php
@@ -2,16 +2,22 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
 
-class Whatsapp implements Channel
+class WhatsApp extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'text' => $params->get('url'),
-        ];
+    use WithShareUrl;
 
-        return 'whatsapp://send' . '?' . http_build_query($query);
+    public function shareBaseUrl(): string
+    {
+        return 'whatsapp://send';
+    }
+
+    public function shareUrlParams(): array
+    {
+        return [
+            'text' => $this->params->get('url'),
+        ];
     }
 }

--- a/src/Channels/Xing.php
+++ b/src/Channels/Xing.php
@@ -2,16 +2,29 @@
 
 namespace Aerni\SocialLinks\Channels;
 
-use Illuminate\Support\Collection;
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+use Aerni\SocialLinks\Concerns\WithShareUrl;
 
-class Xing implements Channel
+class Xing extends Channel
 {
-    public static function create(Collection $params): string
-    {
-        $query = [
-            'url' => $params->get('url'),
-        ];
+    use WithProfileUrl;
+    use WithShareUrl;
 
-        return 'https://www.xing.com/spi/shares/new' . '?' . http_build_query($query);
+    public function profileBaseUrl(): string
+    {
+        return 'https://www.xing.com/profile/';
+    }
+
+    public function shareBaseUrl(): string
+    {
+        return 'https://www.xing.com/spi/shares/new';
+    }
+
+    public function shareUrlParams(): array
+    {
+        return [
+            'url' => $this->params->get('url'),
+        ];
     }
 }

--- a/src/Channels/YouTube.php
+++ b/src/Channels/YouTube.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aerni\SocialLinks\Channels;
+
+use Aerni\SocialLinks\Channels\Channel;
+use Aerni\SocialLinks\Concerns\WithProfileUrl;
+
+class YouTube extends Channel
+{
+    use WithProfileUrl;
+
+    public function profileBaseUrl(): string
+    {
+        return 'https://www.youtube.com/';
+    }
+}

--- a/src/Concerns/WithProfileUrl.php
+++ b/src/Concerns/WithProfileUrl.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Aerni\SocialLinks\Concerns;
+
+use Statamic\Facades\URL;
+
+trait WithProfileUrl
+{
+    abstract protected function profileBaseUrl(): string;
+
+    public function profileUrl(): string
+    {
+        return URL::assemble($this->profileBaseUrl(), $this->params->get('handle'));
+    }
+}

--- a/src/Concerns/WithShareUrl.php
+++ b/src/Concerns/WithShareUrl.php
@@ -10,6 +10,12 @@ trait WithShareUrl
 
     public function shareUrl(): string
     {
-        return $this->shareBaseUrl() . '?' . urldecode(http_build_query($this->shareUrlParams()));
+        $query = http_build_query($this->shareUrlParams());
+
+        if ($this->decodeShareUrlQuery) {
+            $query = urldecode($query);
+        }
+
+        return $this->shareBaseUrl() . '?' . $query;
     }
 }

--- a/src/Concerns/WithShareUrl.php
+++ b/src/Concerns/WithShareUrl.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Aerni\SocialLinks\Concerns;
+
+trait WithShareUrl
+{
+    abstract protected function shareBaseUrl(): string;
+
+    abstract protected function shareUrlParams(): array;
+
+    public function shareUrl(): string
+    {
+        return $this->shareBaseUrl() . '?' . urldecode(http_build_query($this->shareUrlParams()));
+    }
+}


### PR DESCRIPTION
This PR introduces the ability to create social profile links. It's a complete refactor of the codebase. There are some breaking changes in how you're using the tag. Migrating from version 2 should be fairly simple.

**Version 2**
```antlers
{{ social_links:facebook }}
```

**Version 3**
```antlers
{{ social:facebook:share }}
```